### PR TITLE
Allow replacing the branding and nav items

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ INSTALLED_APPS = [
 ]
 ```
 
+Optionally, overwrite the templates `drf_redesign/branding.html` and
+`drf_redesign/nav-items.html` in your application to replace the default
+branding and navbar menu items.
+
 That's it! You're ready to go. 😎
 
 I hope you find this useful. Let me know if you have any feedback or questions. 😊

--- a/drf_redesign/templates/drf_redesign/branding.html
+++ b/drf_redesign/templates/drf_redesign/branding.html
@@ -1,0 +1,16 @@
+{% load i18n static rest_framework rest_framework_redesign %}
+
+{# Branding the left corner of the navigation bar.            #}
+{# Overwrite this template in your application to replace it. #}
+<a class="navbar-brand d-flex align-item-center justify-content-center gap-1 bg-white rounded-4 px-2 shadow-sm"
+  rel="nofollow" href="https://www.django-rest-framework.org/">
+  <span class="fw-bold text-danger">[</span>
+  <span class="fw-bold text-dark">{</span>
+  <strong class="text-dark d-flex align-item-center justify-content-center">
+    <abbr title="Django Rest Framework" data-bs-toggle="tooltip" class="text-decoration-none">
+      {% translate 'DRF' %}
+    </abbr>
+  </strong>
+  <span class="fw-bold text-dark">}</span>
+  <span class="fw-bold text-danger">]</span>
+</a>

--- a/drf_redesign/templates/drf_redesign/branding.html
+++ b/drf_redesign/templates/drf_redesign/branding.html
@@ -1,7 +1,8 @@
-{% load i18n static rest_framework rest_framework_redesign %}
-
 {# Branding the left corner of the navigation bar.            #}
 {# Overwrite this template in your application to replace it. #}
+
+{% load i18n static rest_framework rest_framework_redesign %}
+
 <a class="navbar-brand d-flex align-item-center justify-content-center gap-1 bg-white rounded-4 px-2 shadow-sm"
   rel="nofollow" href="https://www.django-rest-framework.org/">
   <span class="fw-bold text-danger">[</span>

--- a/drf_redesign/templates/drf_redesign/nav-items.html
+++ b/drf_redesign/templates/drf_redesign/nav-items.html
@@ -1,5 +1,6 @@
 {# Menu items for the navigation bar.                           #}
 {# Overwrite this template in your application to replace them. #}
+
 {% load i18n static rest_framework rest_framework_redesign %}
 
 <li class="nav-item">

--- a/drf_redesign/templates/drf_redesign/nav-items.html
+++ b/drf_redesign/templates/drf_redesign/nav-items.html
@@ -1,0 +1,31 @@
+{# Menu items for the navigation bar.                           #}
+{# Overwrite this template in your application to replace them. #}
+{% load i18n static rest_framework rest_framework_redesign %}
+
+<li class="nav-item">
+    <a href="https://www.django-rest-framework.org/" class="nav-link d-flex align-items-center gap-3">
+      <i class="bi bi-house-fill"></i>
+      {% translate "Home" %}
+    </a>
+  </li>
+  <li class="nav-item">
+    <a href="https://www.django-rest-framework.org/tutorial/quickstart/"
+      class="nav-link d-flex align-items-center gap-3">
+      <i class="bi bi-journal-code"></i>
+      {% translate "Tutorial" %}
+    </a>
+  </li>
+  <li class="nav-item">
+    <a href="https://github.com/encode/django-rest-framework/"
+      class="nav-link d-flex align-items-center gap-3">
+      <i class="bi bi-github"></i>
+      {% translate "Github" %}
+    </a>
+  </li>
+  <li class="nav-item">
+    <a href="https://github.com/youzarsiph/rest-framework-redesign/"
+      class="nav-link d-flex align-items-center gap-3">
+      <i class="bi bi-code-slash"></i>
+      {% translate "Redesign" %}
+    </a>
+  </li>

--- a/drf_redesign/templates/drf_redesign/title.html
+++ b/drf_redesign/templates/drf_redesign/title.html
@@ -1,0 +1,1 @@
+{% if name %}{{ name }} – {% endif %}Django REST framework

--- a/drf_redesign/templates/rest_framework/api.html
+++ b/drf_redesign/templates/rest_framework/api.html
@@ -96,18 +96,7 @@
           role="navigation" aria-label="{% translate 'navbar' %}">
           <div class="container-fluid">
             {% block branding %}
-            <a class="navbar-brand d-flex align-item-center justify-content-center gap-1 bg-white rounded-4 px-2 shadow-sm"
-              rel="nofollow" href="https://www.django-rest-framework.org/">
-              <span class="fw-bold text-danger">[</span>
-              <span class="fw-bold text-dark">{</span>
-              <strong class="text-dark d-flex align-item-center justify-content-center">
-                <abbr title="Django Rest Framework" data-bs-toggle="tooltip" class="text-decoration-none">
-                  {% translate 'DRF' %}
-                </abbr>
-              </strong>
-              <span class="fw-bold text-dark">}</span>
-              <span class="fw-bold text-danger">]</span>
-            </a>
+            {% include "drf_redesign/branding.html" %}
             {% endblock %}
 
             <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbar"
@@ -117,33 +106,7 @@
 
             <div class="collapse navbar-collapse" id="navbar">
               <ul class="navbar-nav me-auto">
-                <li class="nav-item">
-                  <a href="https://www.django-rest-framework.org/" class="nav-link d-flex align-items-center gap-3">
-                    <i class="bi bi-house-fill"></i>
-                    {% translate "Home" %}
-                  </a>
-                </li>
-                <li class="nav-item">
-                  <a href="https://www.django-rest-framework.org/tutorial/quickstart/"
-                    class="nav-link d-flex align-items-center gap-3">
-                    <i class="bi bi-journal-code"></i>
-                    {% translate "Tutorial" %}
-                  </a>
-                </li>
-                <li class="nav-item">
-                  <a href="https://github.com/encode/django-rest-framework/"
-                    class="nav-link d-flex align-items-center gap-3">
-                    <i class="bi bi-github"></i>
-                    {% translate "Github" %}
-                  </a>
-                </li>
-                <li class="nav-item">
-                  <a href="https://github.com/youzarsiph/rest-framework-redesign/"
-                    class="nav-link d-flex align-items-center gap-3">
-                    <i class="bi bi-code-slash"></i>
-                    {% translate "Redesign" %}
-                  </a>
-                </li>
+                {% include "drf_redesign/nav-items.html" %}
               </ul>
               <ul class="navbar-nav gap-lg-4">
                 <li class="nav-item dropdown">
@@ -419,7 +382,7 @@
               class="prettyprint mb-0"><code class="language-http" style="padding: 0; background-color: transparent;">{{ request.method }} {{ request.get_full_path }}</code></pre>
           </div>
         </div>
-          
+
 
         <div class="card card-body grid gap-4 rounded-4 p-4 shadow-sm">
           <h3 class="card-title mb-0">Response</h3>

--- a/drf_redesign/templates/rest_framework/api.html
+++ b/drf_redesign/templates/rest_framework/api.html
@@ -7,6 +7,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% endblock %}
 
+{% block title %}{% include "drf_redesign/title.html" %}{% endblock %}
+
 {% block style %}
 {% block bootstrap_theme %}
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"

--- a/drf_redesign/templates/rest_framework/login.html
+++ b/drf_redesign/templates/rest_framework/login.html
@@ -7,6 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% endblock %}
 
+{% block title %}{% include "drf_redesign/title.html" %}{% endblock %}
+
 {% block style %}
   {% block bootstrap_theme %}
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"


### PR DESCRIPTION
Hi,

`drf-redesign` is really nice and a big upgrade from stock DRF. Thanks for making it available. I want to use it in a new project but for this it would be good to replace the branding and nav items with something different, e.g. linking to my project's git repo etc.

So I moved the HTML snippets into two new templates that are now included in `api.html`. If someone wants to keep the default nothing needs to be done. To change them, one can simply replace the two templates in another Django app.

Kind regards, Dennis