### PR TITLE
Remove rest_framework templatetag 'break_long_headers' as removed in DRF

### DIFF
--- a/drf_redesign/templates/rest_framework/api.html
+++ b/drf_redesign/templates/rest_framework/api.html
@@ -397,7 +397,7 @@
 
         <div class="response-info" aria-label="{% translate 'response info' %}">
           <pre class="prettyprint mb-0 d-grid"><code class="language-http">HTTP {{ response.status_code }} {{ response.status_text }}
-{% for key, val in response_headers|items %}{{ key }}: {{ val|break_long_headers|urlize }}
+{% for key, val in response_headers|items %}{{ key }}: {{ val|urlize }}
 {% endfor %}</code><code class="language-json">{{ content|urlize }}</code></pre>
         </div>
       </div>


### PR DESCRIPTION
This templatetag was removed in DRF version [3.16.1](https://github.com/encode/django-rest-framework/releases/tag/3.16.1)

See it removed here: https://github.com/encode/django-rest-framework/pull/9438/files